### PR TITLE
Changes to match the latest AARM report

### DIFF
--- a/Apps/Sudoku.juvix
+++ b/Apps/Sudoku.juvix
@@ -132,11 +132,11 @@ transaction then it is valid. --}
 logicFunction {{Partial}} : Sudoku.Puzzle -> LogicFunction
   | data kind tx :=
     let
-      puzzleDenom : Kind := Sudoku.kind data;
+      puzzleKind : Kind := Sudoku.kind data;
       fromResources : List Resource :=
-        resourcesForKind puzzleDenom (consumedResources tx);
+        resourcesForKind puzzleKind (consumedResources tx);
       toResources : List Resource :=
-        resourcesForKind puzzleDenom (createdResources tx);
+        resourcesForKind puzzleKind (createdResources tx);
       rewardResources : List Resource :=
         resourcesForKind
           Reward.kind

--- a/Apps/Sudoku.juvix
+++ b/Apps/Sudoku.juvix
@@ -48,7 +48,7 @@ module Reward;
     mkResource'
       (logicHash := AlwaysValid.logicHash;
       label := label;
-      dynamicData := nil;
+      data := nil;
       quantity := n);
 
   kind : Kind :=
@@ -69,7 +69,7 @@ module Sudoku;
     mkResource'
       (logicHash := Puzzle.logicHash p;
       label := Puzzle.solution p;
-      dynamicData := d;
+      data := d;
       quantity := n);
 
   kind (p : Puzzle) : Kind :=
@@ -88,8 +88,8 @@ checkTransition {{Partial}} (fromResource : Resource) (toResource : Resource) (r
   : Bool :=
   let
     fromSolution : ByteString :=
-      Resource.dynamicData fromResource;
-    toSolution : ByteString := Resource.dynamicData toResource;
+      Resource.data fromResource;
+    toSolution : ByteString := Resource.data toResource;
     rewardQuantity : Int := Resource.quantity reward;
 
     -- Find the differences between the fromSolution and the toSolution,
@@ -172,7 +172,7 @@ module Dealer;
             (createdResources tx);
 
         checkPuzzle (r : Resource) : Bool :=
-          Sudoku.Puzzle.solution p == Resource.dynamicData r;
+          Sudoku.Puzzle.solution p == Resource.data r;
       in isCreated kind
         || case puzzleResources of {
              | nil := true
@@ -193,7 +193,7 @@ module Dealer;
     mkResource'
       (logicHash := logicHash d;
       label := label d;
-      dynamicData := nil;
+      data := nil;
       quantity := n);
 end;
 

--- a/Apps/Sudoku.juvix
+++ b/Apps/Sudoku.juvix
@@ -39,6 +39,8 @@ import Data.Map as Map open using {Map};
 import Simulator.Prelude open;
 import Stdlib.Trait.Partial open;
 
+open PartialTx;
+
 module Reward;
   label : ByteString := [0];
 
@@ -198,11 +200,10 @@ end;
 dealer (puzzle : Sudoku.Puzzle) (initialBoard : ByteString)
   : PartialTx :=
   mkPartialTx
-    (consumedPair := Reward.mkResource
-        (ofNat (Sudoku.emptySquares initialBoard))
-      , dummyResource;
-    createdPair := Dealer.mkResource puzzle 1
-      , Sudoku.mkResource puzzle initialBoard 1);
+    (consumedResources := [Reward.mkResource
+        (ofNat (Sudoku.emptySquares initialBoard))];
+    createdResources := [Dealer.mkResource puzzle 1;
+      Sudoku.mkResource puzzle initialBoard 1]);
 
 logicFunctions {{Partial}} (puzzle : Sudoku.Puzzle)
   : Map LogicHash LogicFunction :=

--- a/Apps/Sudoku.juvix
+++ b/Apps/Sudoku.juvix
@@ -34,10 +34,7 @@ import Simulator.Resource open using {mkResource as mkResource'};
 import Apps.Sudoku.Validator as Sudoku;
 import Apps.Sudoku.Serializer as Sudoku;
 
-import Simulator.Kind as D;
-
-import Data.Map as Map;
-open Map using {Map};
+import Data.Map as Map open using {Map};
 
 import Simulator.Prelude open;
 import Stdlib.Trait.Partial open;
@@ -173,7 +170,7 @@ module Dealer;
             (createdResources tx);
 
         checkPuzzle (r : Resource) : Bool :=
-          Eq.eq (Sudoku.Puzzle.solution p) (Resource.dynamicData r);
+          Sudoku.Puzzle.solution p == Resource.dynamicData r;
       in isCreated kind
         || case puzzleResources of {
              | nil := true

--- a/Apps/Sudoku/Extra.juvix
+++ b/Apps/Sudoku/Extra.juvix
@@ -25,7 +25,7 @@ allEq {A : Type} {{Eq A}} : List A -> Bool
     let
       go : List A -> Bool
         | nil := true
-        | (y :: ys) := if (Eq.eq x y) (go ys) false;
+        | (y :: ys) := if (x == y) (go ys) false;
     in go xs;
 
 terminating

--- a/Apps/Sudoku/Grid.juvix
+++ b/Apps/Sudoku/Grid.juvix
@@ -4,8 +4,6 @@ import Simulator.Prelude open;
 import Data.ByteString open;
 import Apps.Sudoku.Extra open;
 
-import Stdlib.Data.Nat.Ord open;
-
 --- A Sudoku subgrid
 type SubGrid := subGrid : List (List Nat) -> SubGrid;
 
@@ -34,7 +32,7 @@ gridRows : Grid -> List (List Nat)
 
 instance
 gridEq : Eq Grid :=
-  mkEq λ {g1 g2 := Eq.eq (gridRows g1) (gridRows g2)};
+  mkEq λ {g1 g2 := gridRows g1 == gridRows g2};
 
 prettyGrid : Grid -> String
   | g@(grid (sg@(subGrid (r :: _) :: _) :: _)) :=

--- a/Apps/TwoPartyExchange.juvix
+++ b/Apps/TwoPartyExchange.juvix
@@ -78,10 +78,11 @@ import Simulator open;
 import Simulator.Resource open using {mkResource as mkResource'};
 import Apps.TwoPartyExchange.Asset open;
 
-import Data.Map as Map;
-open Map using {Map};
+import Data.Map as Map open using {Map};
 
 import Simulator.Prelude open;
+
+open PartialTx;
 
 --- Definitions related to Alice's intent
 module AliceIntent;
@@ -118,24 +119,24 @@ end;
 module Alice;
   partialTransaction : PartialTx :=
     mkPartialTx
-      (consumedPair := A.mkResource 1, B.mkResource 2;
-      createdPair := AliceIntent.mkResource 1, dummyResource);
+      (consumedResources := [A.mkResource 1 ; B.mkResource 2];
+      createdResources := [AliceIntent.mkResource 1]);
 end;
 
 --- Definitions related to Bob
 module Bob;
   partialTransaction : PartialTx :=
     mkPartialTx
-      (consumedPair := Dolphin.mkResource 1, dummyResource;
-      createdPair := A.mkResource 1, dummyResource);
+      (consumedResources := [Dolphin.mkResource 1];
+      createdResources := [A.mkResource 1]);
 end;
 
 --- Definitions related to the Solver
 module Solver;
   partialTransaction : PartialTx :=
     mkPartialTx
-      (consumedPair := AliceIntent.mkResource 1, dummyResource;
-      createdPair := Dolphin.mkResource 1, B.mkResource 2);
+      (consumedResources := [AliceIntent.mkResource 1];
+      createdResources := [Dolphin.mkResource 1; B.mkResource 2]);
 end;
 
 logicFunctions : Map LogicHash LogicFunction :=

--- a/Apps/TwoPartyExchange.juvix
+++ b/Apps/TwoPartyExchange.juvix
@@ -1,4 +1,4 @@
-{-
+{--
   A two-party exchange
 
   In this scenario there are ;Resource; types Dolphin, A and B.
@@ -70,7 +70,7 @@
   3.2 (create 1 Dolphin) balances with 2.2 (consume 1 Dolphin)
   3.1 (consume Alice's intent) balances with 1.3 (create Alice's intent)
   2.1 (creates 1 A) balances with 1.1 (consume 1 A).
--}
+--}
 
 module Apps.TwoPartyExchange;
 

--- a/Apps/TwoPartyExchange.juvix
+++ b/Apps/TwoPartyExchange.juvix
@@ -111,7 +111,7 @@ module AliceIntent;
     mkResource'
       (logicHash := logicHash;
       label := label;
-      dynamicData := nil;
+      data := nil;
       quantity := n);
 end;
 

--- a/Apps/TwoPartyExchange/Asset.juvix
+++ b/Apps/TwoPartyExchange/Asset.juvix
@@ -3,11 +3,9 @@ module Apps.TwoPartyExchange.Asset;
 import Simulator open;
 import Simulator.Resource open using {mkResource as mkResource'};
 
-import Data.Map as Map;
-open Map using {Map};
+import Data.Map as Map open using {Map};
 
 import Simulator.Prelude open;
-import Stdlib.Data.Int.Ord open;
 
 --- Definitions related to the Dolphin ;Resource;
 module Dolphin;

--- a/Apps/TwoPartyExchange/Asset.juvix
+++ b/Apps/TwoPartyExchange/Asset.juvix
@@ -15,7 +15,7 @@ module Dolphin;
     mkResource'
       (logicHash := AlwaysValid.logicHash;
       label := label;
-      dynamicData := nil;
+      data := nil;
       quantity := n);
 
   kind : Kind :=
@@ -30,7 +30,7 @@ module A;
     mkResource'
       (logicHash := AlwaysValid.logicHash;
       label := label;
-      dynamicData := nil;
+      data := nil;
       quantity := n);
 
   kind : Kind :=
@@ -45,7 +45,7 @@ module B;
     mkResource'
       (logicHash := AlwaysValid.logicHash;
       label := label;
-      dynamicData := nil;
+      data := nil;
       quantity := n);
 
   kind : Kind :=

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build/AppsTest: $(wildcard *.juvix) $(wildcard ./**/*.juvix)
 	@mkdir -p build
 	juvix compile -o build/AppsTest test/Test/AppsTest.juvix
 
-build/SudokuValidatorTest: $(wildcard ./Sudoku/**/*.juvix) 
+build/SudokuValidatorTest: test/Test/SudokuValidatorTest.juvix $(wildcard ./Apps/Sudoku/**/*.juvix)
 	@mkdir -p build
 	juvix compile -o build/SudokuValidatorTest test/Test/SudokuValidatorTest.juvix
 

--- a/Simulator.juvix
+++ b/Simulator.juvix
@@ -14,6 +14,7 @@ import Data.ByteString open public;
 import Data.Map as Map;
 open Map using {Map};
 open Resource;
+open PartialTx;
 
 validPartialTx {{Partial}} (m : Map
   LogicHash

--- a/Simulator/BuiltinResources.juvix
+++ b/Simulator/BuiltinResources.juvix
@@ -5,21 +5,13 @@ import Simulator.Resource open;
 import Simulator.PartialTx open;
 import Simulator.Prelude open;
 
-import Data.Map as Map;
-open Map using {Map};
+import Data.Map as Map open using {Map};
 
 module AlwaysValid;
   logicFunction : LogicFunction := λ {_ _ := true};
 
   logicHash : LogicHash := 0;
 end;
-
-dummyResource : Resource :=
-  mkResource
-    (logicHash := 0;
-    label := none;
-    dynamicData := none;
-    quantity := 0);
 
 --- Create a map from ;LogicHash; to ;LogicFunction; that includes the AlwaysValid logicFunction
 mkLogicFunctionMap (xs : List (LogicHash × LogicFunction))

--- a/Simulator/PartialTx.juvix
+++ b/Simulator/PartialTx.juvix
@@ -3,21 +3,14 @@ module Simulator.PartialTx;
 import Simulator.Prelude open;
 import Simulator.Resource open;
 
---- A partial transaction consists of two consumed resources and two
---- of created resources
+--- A partial transaction consists of consumed resources and created resources
 type PartialTx :=
   mkPartialTx {
-    consumedPair : Resource × Resource;
-    createdPair : Resource × Resource
+    consumedResources : List Resource;
+    createdResources : List Resource
   };
 
 open PartialTx;
-
-consumedResources (ptx : PartialTx) : List Resource :=
-  case consumedPair ptx of {r1, r2 := [r1; r2]};
-
-createdResources (ptx : PartialTx) : List Resource :=
-  case createdPair ptx of {r1, r2 := [r1; r2]};
 
 {-- A function that determines whether a ;PartialTx; is valid
 

--- a/Simulator/Resource.juvix
+++ b/Simulator/Resource.juvix
@@ -15,7 +15,7 @@ type Resource :=
     -- Specifies the fungibility domain for the resource
     label : ByteString;
     -- Extra data which is not related to the fungibility of the ;Resource;
-    dynamicData : ByteString;
+    data : ByteString;
     -- An integer used to determine balance in transactions.
     quantity : Int
   };
@@ -70,7 +70,7 @@ instance
 ordResource : Ord Resource :=
   let
     prod (r : Resource) : Kind × ByteString × Int :=
-      kind r, dynamicData r, quantity r;
+      kind r, data r, quantity r;
 
     go (r1 : Resource) (r2 : Resource) : Ordering :=
       Ord.cmp (prod r1) (prod r2);

--- a/Simulator/Resource.juvix
+++ b/Simulator/Resource.juvix
@@ -62,9 +62,9 @@ eqResourceKind : Eq ResourceKind :=
       | _ _ := false
     };
 
-isCreated : ResourceKind -> Bool := Eq.eq created;
+isCreated : ResourceKind -> Bool := (==) created;
 
-isConsumed : ResourceKind -> Bool := Eq.eq consumed;
+isConsumed : ResourceKind -> Bool := (==) consumed;
 
 instance
 ordResource : Ord Resource :=

--- a/test/Test/AppsTest.juvix
+++ b/test/Test/AppsTest.juvix
@@ -43,26 +43,32 @@ sudoku {{Partial}} : Test :=
 
     alicePartialTx : PartialTx :=
       mkPartialTx
-        (createdPair := Sudoku.mkResource
-            puzzleData
-            (1 :: 2 :: replicate 14 0)
-            1
-          , Reward.mkResource 1;
-        consumedPair := Sudoku.mkResource
-            puzzleData
-            (1 :: replicate 15 0)
-            1
-          , dummyResource);
+        (createdResources := [ Sudoku.mkResource
+                               puzzleData
+                               (1 :: 2 :: replicate 14 0)
+                               1
+                             ; Reward.mkResource 1
+                             ];
+        consumedResources := [ Sudoku.mkResource
+                               puzzleData
+                               (1 :: replicate 15 0)
+                               1
+                             ]);
 
     bobPartialTx : PartialTx :=
       mkPartialTx
-        (createdPair := Sudoku.mkResource puzzleData solution 0
-          , Reward.mkResource 14;
-        consumedPair := Sudoku.mkResource
-            puzzleData
-            (1 :: 2 :: replicate 14 0)
-            1
-          , Dealer.mkResource puzzleData 1);
+        (createdResources := [ Sudoku.mkResource
+                               puzzleData
+                               solution
+                               0
+                             ; Reward.mkResource 14
+                             ];
+        consumedResources := [ Sudoku.mkResource
+                               puzzleData
+                               (1 :: 2 :: replicate 14 0)
+                               1
+                             ; Dealer.mkResource puzzleData 1
+                             ]);
     txs : List PartialTx :=
       [dealerPartialTx; alicePartialTx; bobPartialTx];
 


### PR DESCRIPTION
This PR contains mostly naming changes to the names now used in the AARM report.

The PartialTx now takes any number of resources instead of a pair of input and a pair of output resources.